### PR TITLE
[Fix] non-android 모듈을 위한 JVM Library Plugin 생성

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -59,5 +59,9 @@ gradlePlugin {
             id = "pochak.android.room"
             implementationClass = "AndroidRoomConventionPlugin"
         }
+        register("jvmLibrary") {
+            id = "pochak.jvm.library"
+            implementationClass = "JvmLibraryConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
@@ -1,0 +1,14 @@
+import com.site.pochak.app.configureKotlinJvm
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class JvmLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("org.jetbrains.kotlin.jvm")
+            }
+            configureKotlinJvm()
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/site/pochak/app/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/site/pochak/app/KotlinAndroid.kt
@@ -3,12 +3,15 @@ package com.site.pochak.app
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.provideDelegate
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinTopLevelExtension
 
 internal fun Project.configureKotlinAndroid(
     commonExtension: CommonExtension<*, *, *, *, *, *>,
@@ -27,16 +30,29 @@ internal fun Project.configureKotlinAndroid(
         }
     }
 
-    configureKotlin()
+    configureKotlin<KotlinAndroidProjectExtension>()
 
     dependencies {
         add("coreLibraryDesugaring", libs.findLibrary("android.desugarJdkLibs").get())
     }
 }
 
-private fun Project.configureKotlin() = configure<KotlinAndroidProjectExtension> {
+internal fun Project.configureKotlinJvm() {
+    extensions.configure<JavaPluginExtension> {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    configureKotlin<KotlinJvmProjectExtension>()
+}
+
+private inline fun <reified T : KotlinTopLevelExtension> Project.configureKotlin() = configure<T> {
     val warningsAsErrors: String? by project
-    compilerOptions.apply {
+    when (this) {
+        is KotlinAndroidProjectExtension -> compilerOptions
+        is KotlinJvmProjectExtension -> compilerOptions
+        else -> TODO("Unsupported project extension $this ${T::class}")
+    }.apply {
         jvmTarget = JvmTarget.JVM_11
         allWarningsAsErrors = warningsAsErrors.toBoolean()
         freeCompilerArgs.add(


### PR DESCRIPTION
non-android 모듈(ex. core 모듈)을 위한 JVM Library Plugin 생성

Fixes: #1 