### PR TITLE
[Fix] ApiResult 함수 호출 에러 수정

### DIFF
--- a/core/network/src/main/kotlin/com/site/pochak/app/core/network/service/MemoriesService.kt
+++ b/core/network/src/main/kotlin/com/site/pochak/app/core/network/service/MemoriesService.kt
@@ -18,22 +18,22 @@ import retrofit2.http.Path
 interface MemoriesService {
 
     @GET(value = "api/v1/memories/{handle}")
-    fun getMemories(
+    suspend fun getMemories(
         @Path(value = "handle") handle: String
     ): NetworkResponse<NetworkMemory>
 
     @GET(value = "api/v1/memories/{handle}/pochaked")
-    fun getPochakedMemories(
+    suspend fun getPochakedMemories(
         @Path(value = "handle") handle: String
     ): NetworkResponse<PostPageResponse>
 
     @GET(value = "api/v1/memories/{handle}/bonded")
-    fun getBondedMemories(
+    suspend fun getBondedMemories(
         @Path(value = "handle") handle: String
     ): NetworkResponse<PostPageResponse>
 
     @GET(value = "api/v1/memories/{handle}/pochak")
-    fun getPochakMemories(
+    suspend fun getPochakMemories(
         @Path(value = "handle") handle: String
     ): NetworkResponse<PostPageResponse>
 

--- a/core/network/src/main/kotlin/com/site/pochak/app/core/network/service/PostService.kt
+++ b/core/network/src/main/kotlin/com/site/pochak/app/core/network/service/PostService.kt
@@ -24,18 +24,18 @@ import retrofit2.http.Query
 interface PostService {
 
     @GET(value = "api/v2/posts")
-    fun getHomePosts(
+    suspend fun getHomePosts(
         @Query(value = "page") page: Int
     ): NetworkResponse<PostPageResponse>
 
     @GET(value = "api/v2/posts/search")
-    fun getSearchPosts(
+    suspend fun getSearchPosts(
         @Query(value = "page") page: Int
     ): NetworkResponse<PostPageResponse>
 
     @Multipart
     @POST(value = "api/v2/posts")
-    fun postPost(
+    suspend fun postPost(
         @Part postImage: MultipartBody.Part,
 
         @Query("taggedMemberHandleList") taggedMemberHandleList: List<String>,
@@ -43,12 +43,12 @@ interface PostService {
     ): NetworkResponse<Unit>
 
     @GET(value = "api/v2/posts/{postId}")
-    fun getPostDetail(
+    suspend fun getPostDetail(
         @Query(value = "postId") postId: Int
     ): NetworkResponse<NetworkPostDetail>
 
     @DELETE(value = "api/v2/posts/{postId}")
-    fun deletePost(
+    suspend fun deletePost(
         @Query(value = "postId") postId: Int
     ): NetworkResponse<Unit>
 

--- a/core/network/src/main/kotlin/com/site/pochak/app/core/network/service/ReportService.kt
+++ b/core/network/src/main/kotlin/com/site/pochak/app/core/network/service/ReportService.kt
@@ -13,7 +13,7 @@ import retrofit2.http.Query
 interface ReportService {
 
     @POST(value = "api/v2/reports")
-    fun postReport(
+    suspend fun postReport(
         @Query(value = "postId") postId: Int,
         @Query(value = "reportType") reportType: String
     ): NetworkResponse<Unit>

--- a/core/network/src/main/kotlin/com/site/pochak/app/core/network/service/SearchService.kt
+++ b/core/network/src/main/kotlin/com/site/pochak/app/core/network/service/SearchService.kt
@@ -14,7 +14,7 @@ import retrofit2.http.Query
 interface SearchService {
 
     @GET(value = "api/v2/members/search")
-    fun searchMembers(
+    suspend fun searchMembers(
         @Query(value = "keyword") keyword: String,
         @Query(value = "page") page: Int
     ): NetworkResponse<MemberPageResponse>

--- a/core/network/src/main/kotlin/com/site/pochak/app/core/network/service/TagService.kt
+++ b/core/network/src/main/kotlin/com/site/pochak/app/core/network/service/TagService.kt
@@ -13,7 +13,7 @@ import retrofit2.http.Query
 interface TagService {
 
     @GET(value = "api/v2/tags/{tagId}")
-    fun approveTag(
+    suspend fun approveTag(
         @Query(value = "tagId") tagId: Int,
         @Query(value = "isAccept") isAccept: Boolean
     ): NetworkResponse<Unit>

--- a/core/network/src/main/kotlin/com/site/pochak/app/core/network/service/TokenService.kt
+++ b/core/network/src/main/kotlin/com/site/pochak/app/core/network/service/TokenService.kt
@@ -16,5 +16,5 @@ import retrofit2.http.POST
 interface TokenService {
 
     @POST(value = "api/v2/refresh")
-    fun refreshToken(@HeaderMap headers: Map<String, String>): Call<NetworkResponse<NetworkToken>>
+    suspend fun refreshToken(@HeaderMap headers: Map<String, String>): Call<NetworkResponse<NetworkToken>>
 }

--- a/core/network/src/main/kotlin/com/site/pochak/app/core/network/utils/ApiResultHandler.kt
+++ b/core/network/src/main/kotlin/com/site/pochak/app/core/network/utils/ApiResultHandler.kt
@@ -8,7 +8,7 @@ object ApiResultHandler {
         apiCall: suspend () -> NetworkResponse<T>
     ): ApiResult {
         return try {
-            val response = apiCall()
+            val response = apiCall.invoke()
 
             if (response.isSuccess) {
                 if (response.result != null) {


### PR DESCRIPTION
## 💌 작업한 내용
ApiResult의 apiCall 호출 시, suspend 키워드 없는 함수들에서 에러 발생

## 💭 PR POINT
ApiResult의 apiCall 호출 시, suspend 키워드 없는 함수들에서 에러 발생

## 💐 관련 이슈

- Resolved: #19 
