### PR TITLE
[Feat] UI 디자인 스타일 가이드 적용

### DIFF
--- a/app/src/main/kotlin/com/site/pochak/app/navigation/PochakNavHost.kt
+++ b/app/src/main/kotlin/com/site/pochak/app/navigation/PochakNavHost.kt
@@ -1,5 +1,7 @@
 package com.site.pochak.app.navigation
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
@@ -33,6 +35,8 @@ fun PochakNavHost(
         navController = navController,
         startDestination = SplashRoute,
         modifier = modifier,
+        enterTransition = { EnterTransition.None },
+        exitTransition = { ExitTransition.None },
     ) {
         splashScreen(
             navigateToHome = {

--- a/core/designsystem/src/main/kotlin/com/site/pochak/app/core/designsystem/component/Dialog.kt
+++ b/core/designsystem/src/main/kotlin/com/site/pochak/app/core/designsystem/component/Dialog.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.site.pochak.app.core.designsystem.theme.Gray01
 import com.site.pochak.app.core.designsystem.theme.Gray05
-import com.site.pochak.app.core.designsystem.theme.Yellow01
+import com.site.pochak.app.core.designsystem.theme.Yellow00
 
 @Composable
 fun PochakAlertDialog(
@@ -104,7 +104,7 @@ fun PochakAlertDialog(
                         Text(
                             text = confirmButtonText,
                             style = MaterialTheme.typography.titleSmall,
-                            color = Yellow01
+                            color = Yellow00
                         )
                     }
                 }

--- a/core/designsystem/src/main/kotlin/com/site/pochak/app/core/designsystem/component/Padding.kt
+++ b/core/designsystem/src/main/kotlin/com/site/pochak/app/core/designsystem/component/Padding.kt
@@ -2,4 +2,5 @@ package com.site.pochak.app.core.designsystem.component
 
 import androidx.compose.ui.unit.dp
 
-val HorizontalPadding = 18.dp
+val HorizontalPadding = 20.dp
+val VerticalPadding = 16.dp

--- a/core/designsystem/src/main/kotlin/com/site/pochak/app/core/designsystem/component/VerticalGrid.kt
+++ b/core/designsystem/src/main/kotlin/com/site/pochak/app/core/designsystem/component/VerticalGrid.kt
@@ -39,7 +39,7 @@ fun RefreshableLazyVerticalGrid(
     threshold: Dp = 80.dp,
     state: LazyGridState = rememberLazyGridState(),
     columns: GridCells = GridCells.Fixed(1),
-    contentPadding: PaddingValues = PaddingValues(horizontal = 20.dp, vertical = 16.dp),
+    contentPadding: PaddingValues = PaddingValues(horizontal = HorizontalPadding, vertical = VerticalPadding),
     verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(8.dp),
     horizontalArrangement: Arrangement.Horizontal = Arrangement.spacedBy(8.dp),
     loadMoreLimitCount: Int = 3,

--- a/core/designsystem/src/main/kotlin/com/site/pochak/app/core/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/kotlin/com/site/pochak/app/core/designsystem/theme/Color.kt
@@ -6,8 +6,8 @@ import androidx.compose.ui.graphics.Color
  *  Color Palette
  *
  *  Primary
- *  Yellow01: #FFB83B   -> Primary
- *  Yellow02: #FFF1D8   -> Primary
+ *  Yellow00: #FFB83B   -> Primary
+ *  Yellow01: #FFF1D8   -> Primary
  *
  *  Secondary
  *  Navy10: #0B1217
@@ -28,8 +28,8 @@ import androidx.compose.ui.graphics.Color
  *  Gray07: #212529
  */
 
-val Yellow01 = Color(0xFFFFB83B)
-val Yellow02 = Color(0xFFFFF1D8)
+val Yellow00 = Color(0xFFFFB83B)
+val Yellow01 = Color(0xFFFFF1D8)
 
 val Navy10 = Color(0xFF0B1217)
 val Navy00 = Color(0xFF16242E)

--- a/core/designsystem/src/main/kotlin/com/site/pochak/app/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/kotlin/com/site/pochak/app/core/designsystem/theme/Theme.kt
@@ -2,19 +2,21 @@ package com.site.pochak.app.core.designsystem.theme
 
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Typography
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 
 /**
  * Light default theme color scheme
  */
 val LightColorScheme = lightColorScheme(
-    primary = Yellow01,
+    primary = Yellow00,
     onPrimary = Color.White,
     secondary = Navy03,
-    onSecondary = Color.Black
+    onSecondary = Color.Black,
 )
 
 /**
@@ -32,12 +34,30 @@ fun PochakTheme(
 ) {
     val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
 
+    val density = LocalDensity.current
+    val typography = with(PochakTypography) {
+        Typography(
+            displaySmall = displaySmall.toTextStyleDp(density),
+            headlineLarge = headlineLarge.toTextStyleDp(density),
+            headlineMedium = headlineMedium.toTextStyleDp(density),
+            headlineSmall = headlineSmall.toTextStyleDp(density),
+            titleLarge = titleLarge.toTextStyleDp(density),
+            titleMedium = titleMedium.toTextStyleDp(density),
+            titleSmall = titleSmall.toTextStyleDp(density),
+            bodyLarge = bodyLarge.toTextStyleDp(density),
+            bodyMedium = bodyMedium.toTextStyleDp(density),
+            bodySmall = bodySmall.toTextStyleDp(density),
+            labelLarge = labelLarge.toTextStyleDp(density),
+            labelMedium = labelMedium.toTextStyleDp(density),
+        )
+    }
+
     CompositionLocalProvider(
         // Gradient Color, Background Color, etc.
     ) {
         MaterialTheme(
             colorScheme = colorScheme,
-            typography = PochakTypography,
+            typography = typography,
             content = content
         )
     }

--- a/core/designsystem/src/main/kotlin/com/site/pochak/app/core/designsystem/theme/Type.kt
+++ b/core/designsystem/src/main/kotlin/com/site/pochak/app/core/designsystem/theme/Type.kt
@@ -1,10 +1,11 @@
 package com.site.pochak.app.core.designsystem.theme
 
-import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.site.pochak.app.core.designsystem.R
 
@@ -37,89 +38,92 @@ private val Pretendard = FontFamily(
  * caption2: Medium, 12px, 16px, 0px    -> labelMedium
  *
  */
-internal val PochakTypography = Typography(
-    displaySmall = TextStyle(
-        fontFamily = Pretendard,
+object PochakTypography {
+    data class FontInfo(
+        val fontFamily: FontFamily = Pretendard,
+        val fontWeight: FontWeight,
+        val fontSize: Float,
+        val lineHeight: Float,
+        val letterSpacing: Float = 0f
+    ) {
+        fun toTextStyle() = TextStyle(
+            fontFamily = fontFamily,
+            fontWeight = fontWeight,
+            fontSize = fontSize.sp,
+            lineHeight = lineHeight.sp,
+            letterSpacing = letterSpacing.sp
+        )
+
+        fun toTextStyleDp(density: Density) = with(density) {
+            TextStyle(
+                fontFamily = fontFamily,
+                fontWeight = fontWeight,
+                fontSize = fontSize.dp.toSp(),
+                lineHeight = lineHeight.dp.toSp(),
+                letterSpacing = letterSpacing.dp.toSp()
+            )
+        }
+    }
+
+    val displaySmall = FontInfo(
         fontWeight = FontWeight.Bold,
-        fontSize = 26.sp,
-        lineHeight = 30.sp,
-        letterSpacing = 0.sp
-    ),
-    headlineLarge = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Bold,
-        fontSize = 22.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
-    ),
-    headlineMedium = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Medium,
-        fontSize = 22.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
-    ),
-    headlineSmall = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Bold,
-        fontSize = 20.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
-    ),
-    titleLarge = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Medium,
-        fontSize = 20.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
-    ),
-    titleMedium = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Bold,
-        fontSize = 18.sp,
-        lineHeight = 24.sp,
-        letterSpacing = 0.sp
-    ),
-    titleSmall = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Bold,
-        fontSize = 16.sp,
-        lineHeight = 22.sp,
-        letterSpacing = 0.sp
-    ),
-    bodyLarge = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Medium,
-        fontSize = 16.sp,
-        lineHeight = 22.sp,
-        letterSpacing = 0.sp
-    ),
-    bodyMedium = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Normal,
-        fontSize = 14.sp,
-        lineHeight = 20.sp,
-        letterSpacing = 0.sp
-    ),
-    bodySmall = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Bold,
-        fontSize = 14.sp,
-        lineHeight = 20.sp,
-        letterSpacing = 0.sp
-    ),
-    labelLarge = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Bold,
-        fontSize = 12.sp,
-        lineHeight = 16.sp,
-        letterSpacing = 0.sp
-    ),
-    labelMedium = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Medium,
-        fontSize = 12.sp,
-        lineHeight = 16.sp,
-        letterSpacing = 0.sp
+        fontSize = 26f,
+        lineHeight = 30f,
     )
-)
+    val headlineLarge = FontInfo(
+        fontWeight = FontWeight.Bold,
+        fontSize = 22f,
+        lineHeight = 28f,
+    )
+    val headlineMedium = FontInfo(
+        fontWeight = FontWeight.Medium,
+        fontSize = 22f,
+        lineHeight = 28f,
+    )
+    val headlineSmall = FontInfo(
+        fontWeight = FontWeight.Bold,
+        fontSize = 20f,
+        lineHeight = 28f,
+    )
+    val titleLarge = FontInfo(
+        fontWeight = FontWeight.Medium,
+        fontSize = 20f,
+        lineHeight = 28f,
+    )
+    val titleMedium = FontInfo(
+        fontWeight = FontWeight.Bold,
+        fontSize = 18f,
+        lineHeight = 24f,
+        letterSpacing = 0.1f
+    )
+    val titleSmall = FontInfo(
+        fontWeight = FontWeight.Bold,
+        fontSize = 16f,
+        lineHeight = 22f,
+    )
+    val bodyLarge = FontInfo(
+        fontWeight = FontWeight.Medium,
+        fontSize = 16f,
+        lineHeight = 22f,
+    )
+    val bodyMedium = FontInfo(
+        fontWeight = FontWeight.Normal,
+        fontSize = 14f,
+        lineHeight = 20f,
+    )
+    val bodySmall = FontInfo(
+        fontWeight = FontWeight.Bold,
+        fontSize = 14f,
+        lineHeight = 20f,
+    )
+    val labelLarge = FontInfo(
+        fontWeight = FontWeight.Bold,
+        fontSize = 12f,
+        lineHeight = 16f,
+    )
+    val labelMedium = FontInfo(
+        fontWeight = FontWeight.Medium,
+        fontSize = 12f,
+        lineHeight = 16f,
+    )
+}

--- a/feature/camera/src/main/kotlin/com/site/pochak/app/feature/camera/UploadScreen.kt
+++ b/feature/camera/src/main/kotlin/com/site/pochak/app/feature/camera/UploadScreen.kt
@@ -55,7 +55,7 @@ import com.site.pochak.app.core.designsystem.theme.Gray02
 import com.site.pochak.app.core.designsystem.theme.Gray03
 import com.site.pochak.app.core.designsystem.theme.Gray0_5
 import com.site.pochak.app.core.designsystem.theme.Navy00
-import com.site.pochak.app.core.designsystem.theme.Yellow02
+import com.site.pochak.app.core.designsystem.theme.Yellow01
 import java.io.File
 
 @Composable
@@ -350,7 +350,7 @@ fun SelectedItemView(
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
-            .background(Yellow02, shape = RoundedCornerShape(6.dp))
+            .background(Yellow01, shape = RoundedCornerShape(6.dp))
             .wrapContentWidth()
             .padding(horizontal = 10.dp, vertical = 8.dp)
     ) {

--- a/feature/profile-setting/src/main/kotlin/com/site/pochak/app/feature/profile/setting/ProfileSettingScreen.kt
+++ b/feature/profile-setting/src/main/kotlin/com/site/pochak/app/feature/profile/setting/ProfileSettingScreen.kt
@@ -64,7 +64,7 @@ import com.site.pochak.app.core.designsystem.component.PochakTopAppBar
 import com.site.pochak.app.core.designsystem.theme.Gray01
 import com.site.pochak.app.core.designsystem.theme.Gray03
 import com.site.pochak.app.core.designsystem.theme.Gray04
-import com.site.pochak.app.core.designsystem.theme.Yellow01
+import com.site.pochak.app.core.designsystem.theme.Yellow00
 import java.io.File
 
 private const val TAG = "ProfileSettingScreen"
@@ -242,7 +242,7 @@ private fun ProfileSettingContent(
                     Text(
                         text = stringResource(R.string.feature_profile_setting_save),
                         style = MaterialTheme.typography.titleSmall,
-                        color = if (actionEnabled) Yellow01 else Gray03,
+                        color = if (actionEnabled) Yellow00 else Gray03,
                     )
                 }
             },


### PR DESCRIPTION
## 💌 작업한 내용
- Typography font size: dp, sp 둘 다 가능하도록 세팅
- Typography 변경된 값 적용
- 좌우 여백 마진 20dp로 변경
- 화면 전환 애니메이션 제거


## 💭 PR POINT
typography의 폰트 정보에 대한 이름(DisplayLarge, DisplayMedium... 등)은 피그마 최종 디자인에 옛날 버전 이름으로 남아있어서 변경하지 않았고, 추후에 변경되는거에 맞춰서 한번 더 수정해야할 것 같습니다...
또한, 고정형 폰트 사이즈는 theme 설정하는 과정에서 모든 폰트에 한번에 지정해두었습니다.
``` kotlin
Typography(
            displaySmall = displaySmall.toTextStyleDp(density),
            ...
)

// sp 사용하고 싶을 경우
Text(
    text = ""
    style = MaterialTheme.typography.displaySmall.copy(fontSize = ?.sp)
)
```

패딩 값은 designsystem 모듈의 Padding.kt 파일에 정의해두었고, 개발 중 공통된 패딩값 있으면 추가해주세요!

## 💐 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #25
