### PR TITLE
[Feat] 아이디검색, 팔로우 알림 프로필 화면으로 이동

### DIFF
--- a/app/src/main/kotlin/com/site/pochak/app/navigation/PochakNavHost.kt
+++ b/app/src/main/kotlin/com/site/pochak/app/navigation/PochakNavHost.kt
@@ -79,7 +79,11 @@ fun PochakNavHost(
             navigateToSearchHistory = navController::navigateToSearchHistory,
             navigateToPostDetail = navController::navigateToPostDetail
         )
-        searchHistoryScreen()
+        searchHistoryScreen(
+            navigateToProfile = { handle ->
+                navController.navigateToProfile(handle = handle)
+            }
+        )
         postDetailScreen(
             onBack = { navController.popBackStack() },
             navigateToProfile = { handle ->

--- a/app/src/main/kotlin/com/site/pochak/app/navigation/PochakNavHost.kt
+++ b/app/src/main/kotlin/com/site/pochak/app/navigation/PochakNavHost.kt
@@ -103,7 +103,10 @@ fun PochakNavHost(
             }
         )
         alarmScreen(
-            navigateToPostDetail = navController::navigateToPostDetail
+            navigateToPostDetail = navController::navigateToPostDetail,
+            navigateToProfile = { handle ->
+                navController.navigateToProfile(handle = handle)
+            }
         )
         profileGraph(
             onBack = { navController.popBackStack() },

--- a/feature/alarm/src/main/kotlin/com/site/pochak/app/feature/alarm/AlarmScreen.kt
+++ b/feature/alarm/src/main/kotlin/com/site/pochak/app/feature/alarm/AlarmScreen.kt
@@ -64,7 +64,8 @@ internal fun AlarmRoute(
     modifier: Modifier = Modifier,
     viewModel: AlarmViewModel = hiltViewModel(),
     navigateToPostDetail: (Int) -> Unit,
-    ) {
+    navigateToProfile: (String) -> Unit
+) {
     val allAlarms = viewModel.allAlarms.collectAsStateWithLifecycle()
     val isLoading = viewModel.isLoading.collectAsStateWithLifecycle()
     val isRefreshing = viewModel.isRefreshing.collectAsStateWithLifecycle()
@@ -76,7 +77,8 @@ internal fun AlarmRoute(
         isLoading = isLoading.value,
         isRefreshing = isRefreshing.value,
         onLoadPage = viewModel::loadPage,
-        onPostDetailClick = navigateToPostDetail
+        onPostAlarmClick = navigateToPostDetail,
+        onFollowAlarmClick = navigateToProfile
     )
 }
 
@@ -88,7 +90,8 @@ internal fun AlarmScreen(
     isLoading: Boolean,
     isRefreshing: Boolean,
     onLoadPage: (Boolean) -> Unit,
-    onPostDetailClick: (Int) -> Unit,
+    onPostAlarmClick: (Int) -> Unit,
+    onFollowAlarmClick: (String) -> Unit
 ) {
     Column(
         modifier = modifier
@@ -106,7 +109,8 @@ internal fun AlarmScreen(
             isLoading = isLoading,
             isRefreshing = isRefreshing,
             onLoadPage = onLoadPage,
-            onPostDetailClick = onPostDetailClick
+            onPostDetailClick = onPostAlarmClick,
+            onFollowAlarmClick = onFollowAlarmClick
         )
     }
 }
@@ -121,6 +125,7 @@ fun AlarmContent(
     isRefreshing: Boolean,
     onLoadPage: (Boolean) -> Unit,
     onPostDetailClick: (Int) -> Unit,
+    onFollowAlarmClick: (String) -> Unit
 ) {
     val selectedTagId by viewModel.selectedTagId.collectAsState()
     val postPreviewUiState by viewModel.postPreviewUiState
@@ -148,6 +153,7 @@ fun AlarmContent(
                 alarm = alarm,
                 viewModel = viewModel,
                 onPostDetailClick = onPostDetailClick,
+                onFollowAlarmClick = onFollowAlarmClick
             )
         }
 
@@ -189,6 +195,7 @@ fun AlarmItem(
     alarm: Alarm,
     viewModel: AlarmViewModel,
     onPostDetailClick: (Int) -> Unit,
+    onFollowAlarmClick: (String) -> Unit
 ) {
     var isClicked by rememberSaveable { mutableStateOf(false) }
 
@@ -229,7 +236,7 @@ fun AlarmItem(
                             viewModel.getPostPreview(alarm.alarmId) // 태그 미리보기 가져오기
                         }
                         AlarmType.FOLLOW -> {
-                            // 해당 프로필로 이동
+                            alarm.memberHandle?.let { onFollowAlarmClick(it) } // 팔로우한 유저 프로필로 이동
                         }
                         else -> {
                             onPostDetailClick(alarm.postId!!.toInt()) // 게시물 상세로 이동

--- a/feature/alarm/src/main/kotlin/com/site/pochak/app/feature/alarm/navigation/AlarmNavigation.kt
+++ b/feature/alarm/src/main/kotlin/com/site/pochak/app/feature/alarm/navigation/AlarmNavigation.kt
@@ -13,10 +13,12 @@ fun NavController.navigateToAlarm(navOptions: NavOptions? = null) = navigate(Ala
 
 fun NavGraphBuilder.alarmScreen(
     navigateToPostDetail: (Int) -> Unit,
-) {
+    navigateToProfile: (String) -> Unit
+    ) {
     composable<AlarmRoute> {
         AlarmRoute(
-            navigateToPostDetail = navigateToPostDetail
+            navigateToPostDetail = navigateToPostDetail,
+            navigateToProfile = navigateToProfile
         )
     }
 }

--- a/feature/post/src/main/kotlin/com/site/pochak/app/feature/post/SearchHistoryScreen.kt
+++ b/feature/post/src/main/kotlin/com/site/pochak/app/feature/post/SearchHistoryScreen.kt
@@ -63,10 +63,12 @@ import com.site.pochak.app.core.network.model.NetworkMember
 internal fun SearchHistoryRoute(
     modifier: Modifier = Modifier,
     viewModel: SearchHistoryViewModel = hiltViewModel(),
+    navigateToProfile: (String) -> Unit
 ) {
     SearchHistoryScreen(
         modifier = modifier.padding(horizontal = HorizontalPadding),
         viewModel = viewModel,
+        navigateToProfile = navigateToProfile
     )
 }
 
@@ -74,6 +76,7 @@ internal fun SearchHistoryRoute(
 internal fun SearchHistoryScreen(
     modifier: Modifier = Modifier,
     viewModel: SearchHistoryViewModel,
+    navigateToProfile: (String) -> Unit
 ) {
     val recentSearches by viewModel.recentSearches.observeAsState(emptyList())
     val currentKeyword by viewModel.currentKeyword.collectAsStateWithLifecycle()
@@ -97,13 +100,18 @@ internal fun SearchHistoryScreen(
                 viewModel = viewModel,
                 searchResults = searchResults,
                 isLoading = isLoading,
-                onClick = { /* Navigate to the profile */ }
+                onClick = {
+                    navigateToProfile(it.handle)
+                }
             )
         } else {
             RecentSearchesContent(
                 modifier = Modifier,
                 viewModel = viewModel,
                 recentSearches = recentSearches,
+                onClick = {
+                    navigateToProfile(it.handle)
+                }
             )
         }
     }
@@ -229,6 +237,7 @@ fun RecentSearchesContent(
     modifier: Modifier,
     viewModel: SearchHistoryViewModel,
     recentSearches: List<RecentSearch>,
+    onClick: (RecentSearch) -> Unit
 ) {
     Column(
         modifier = modifier
@@ -245,7 +254,7 @@ fun RecentSearchesContent(
             modifier = Modifier,
             viewModel = viewModel,
             recentSearches = recentSearches,
-            onClick = { /* Navigate to the profile */ }
+            onClick = { onClick(it) }
         )
     }
 }

--- a/feature/post/src/main/kotlin/com/site/pochak/app/feature/post/SearchHistoryScreen.kt
+++ b/feature/post/src/main/kotlin/com/site/pochak/app/feature/post/SearchHistoryScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -303,6 +304,7 @@ fun RecentSearchItemList(
             .padding(top = 12.dp),
         contentPadding = PaddingValues(horizontal = 0.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
+        columns = GridCells.Fixed(1),
     ) {
         items(recentSearches) { member ->
             RecentSearchRow(

--- a/feature/post/src/main/kotlin/com/site/pochak/app/feature/post/navigation/PostNavigation.kt
+++ b/feature/post/src/main/kotlin/com/site/pochak/app/feature/post/navigation/PostNavigation.kt
@@ -27,8 +27,11 @@ fun NavGraphBuilder.postScreen(
 }
 
 fun NavGraphBuilder.searchHistoryScreen(
+    navigateToProfile: (String) -> Unit
 ) {
     composable<SearchHistoryRoute> {
-        SearchHistoryRoute()
+        SearchHistoryRoute(
+            navigateToProfile = navigateToProfile
+        )
     }
 }


### PR DESCRIPTION
## 💌 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 아이디검색에서 남의 프로필 화면으로 이동
- 팔로우 알림에서 남의 프로필 화면으로 이동


## 💭 PR POINT
- 


## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 프로필 연결 | <video src="https://github.com/user-attachments/assets/4eba209f-4a0b-4f15-9bec-d232f34031ae" width="250" controls></video>|


## 💐 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #44 
